### PR TITLE
[OPC2PRADA] reply via RPC with Objects names and IDS

### DIFF
--- a/src/opc2prada/include/OPC2PRADA_IDL.h
+++ b/src/opc2prada/include/OPC2PRADA_IDL.h
@@ -20,6 +20,11 @@ public:
    */
   virtual bool update();
   /**
+   * Load correspondence between ID and Labels in the DataBase
+   * @return Bottle with ID and Objects names
+   */
+  virtual yarp::os::Bottle loadObjects();
+  /**
    * Bottle
    * @return Bottle with 2d features
    */

--- a/src/opc2prada/include/translator.h
+++ b/src/opc2prada/include/translator.h
@@ -84,6 +84,7 @@ public:
     bool attach(yarp::os::RpcServer &source);
     Bottle query2d(const int32_t ObjectID);
     Bottle querytool2d(const int32_t ObjectID);
+    Bottle loadObjects();
     bool update();
     bool quit();
 

--- a/src/opc2prada/opc2prada.thrift
+++ b/src/opc2prada/opc2prada.thrift
@@ -21,7 +21,13 @@ service OPC2PRADA_IDL
   * @return true/false on success/failure
   */
   bool update();
-
+  
+  /**
+  * Load correspondence between ID and Labels in the DataBase
+  * 
+  * @return Bottle with ID and Objects names
+  */
+  Bottle loadObjects();
 
   /**
   * Bottle

--- a/src/opc2prada/src/translator.cpp
+++ b/src/opc2prada/src/translator.cpp
@@ -38,7 +38,32 @@ bool TranslatorModule::quit() {
     cout << "Received Quit command in RPC" << endl;
     return true;
 }
-
+Bottle TranslatorModule::loadObjects(){
+    Bottle *receive,dataBase,ids2,*idsp;
+    Bottle response;
+    cout << "Received loadObjects command in RPC" << endl;
+    readingThread->guard.lock();
+    dataBase = readingThread->_data;
+    ids2 = readingThread->_ids;
+    readingThread->guard.unlock();
+    if(dataBase.size()>0 && (dataBase.get(1).asString()!="empty")) {
+        idsp = ids2.get(1).asList();
+        idsp = idsp->get(1).asList();
+        for(int i=1;i<dataBase.size();i++){ // for each object
+            Bottle *objecto = dataBase.get(i).asList();
+            for(int j=0;j<objecto->size();j++) { // for each properties
+                Bottle *propriedade = objecto->get(j).asList();
+                if(propriedade->get(0).asString() == "name"){
+                    Bottle aux;
+                    aux.addInt(idsp->get((i-1)).asInt());
+                    aux.addString(propriedade->get(1).asString());
+                    response.addList() = aux;
+                }
+            }
+        }
+    }
+    return response;
+}
 bool TranslatorModule::update(){
 
     Bottle *receive,dataBase,ids2,*idsp;


### PR DESCRIPTION
Now opc2prada reply to the planner via RPC (loadObjects) with a Bottle.

For now the file "object-names-ids.dat" will be created also, in a near future it will be removed.

See #115