### PR TITLE
refactor worldStateManager

### DIFF
--- a/src/worldStateManager/include/Helpers.h
+++ b/src/worldStateManager/include/Helpers.h
@@ -20,11 +20,31 @@
 #include <yarp/sig/Vector.h>
 
 /**********************************************************/
+// http://stackoverflow.com/a/29798
+inline const char * const BoolToString(bool &b)
+{
+    return b ? "true" : "false";
+}
+
+/**********************************************************/
+struct compareSecond
+{
+    template <typename Pair>
+    bool operator()(const Pair &a, const Pair &b)
+    {
+        return a.second < b.second;
+    }
+};
+
+/**********************************************************/
 template<class key,class val>
 void dumpMap(const std::map<key,val> &m)
 {
-    std::ostringstream fullMapContent; // output stream we'll feed to yDebug macro
-    size_t items_remaining = m.size(); // http://stackoverflow.com/a/151112
+    // output stream we'll feed to yDebug macro
+    std::ostringstream fullMapContent;
+
+    // http://stackoverflow.com/a/151112
+    size_t items_remaining = m.size();
     bool last_iteration = false; 
     for(typename std::map<key,val>::const_iterator iter = m.begin();
         iter != m.end();
@@ -46,14 +66,26 @@ bool is_integer(const float k);
 
 /**********************************************************/
 template<class key,class val>
-bool mergeMaps(const std::map<key,val> &map1, const std::map<key,val> &map2, std::map<key,val> &result)
+bool mapContainsKey(const std::map<key,val> &m, const key &k)
 {
-    result = map1;
-    result.insert(map2.begin(), map2.end());
-    return true;
+    return m.count(k); // 1 if element present in the map, 0 otherwise
 }
 
 /**********************************************************/
-bool vectorsDiffer(const std::vector<int> &v1, const std::vector<int> &v2);
+template<class key,class val>
+bool mapContainsValue(const std::map<key,val> &m, const val &v)
+{
+    bool found = false;
+
+    for(typename std::map<key,val>::const_iterator iter = m.begin();
+        iter != m.end();
+        ++iter)
+    {
+        if (iter->second == v)
+            found = true;
+    }
+
+    return found;
+}
 
 #endif

--- a/src/worldStateManager/include/MemoryItem.h
+++ b/src/worldStateManager/include/MemoryItem.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright: (C) 2012-2015 POETICON++, European Commission FP7 project ICT-288382
+ * Copyright: (C) 2015 VisLab, Institute for Systems and Robotics,
+ *                Instituto Superior Técnico, Universidade de Lisboa, Lisbon, Portugal
+ * Author: Giovanni Saponaro <gsaponaro@isr.ist.utl.pt>
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0
+ *
+ */
+
+#ifndef __SHORT_TERM_MEMORY_ITEM_H__
+#define __SHORT_TERM_MEMORY_ITEM_H__
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+struct MemoryItem
+{
+    const int id;
+    const string name;
+    const bool isHand;
+
+    // constructor
+    MemoryItem(const int _id, const string _name, const bool _isHand)
+    : id(_id), name(_name), isHand(_isHand)
+    {}
+
+    // copy constructor
+    MemoryItem(const MemoryItem& other)
+    : id(other.id), name(other.name), isHand(other.isHand)
+    {}
+
+    // copy assignment operator
+    MemoryItem& operator=(const MemoryItem& mi)
+    {
+        // TODO: fix
+        /*
+        if(this != &mi)
+        {
+            name = mi.name;
+            isHand = mi.isHand;
+        }
+        */
+        return *this;
+    }
+
+    // destructor
+    virtual ~MemoryItem()
+    {}
+
+    // http://stackoverflow.com/questions/1549930/c-equivalent-of-java-tostring
+    virtual std::ostream& toString(std::ostream& o) const
+    {
+        return o << "id=" << id << " name=" << name;
+    }
+};
+
+// inline because http://stackoverflow.com/questions/12802536/c-multiple-definitions-of-operator
+inline ostream& operator<<(ostream& str, const MemoryItem& mi)
+{
+    return mi.toString(str);
+}
+
+#endif

--- a/src/worldStateManager/include/MemoryItemHand.h
+++ b/src/worldStateManager/include/MemoryItemHand.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright: (C) 2012-2015 POETICON++, European Commission FP7 project ICT-288382
+ * Copyright: (C) 2015 VisLab, Institute for Systems and Robotics,
+ *                Instituto Superior Técnico, Universidade de Lisboa, Lisbon, Portugal
+ * Author: Giovanni Saponaro <gsaponaro@isr.ist.utl.pt>
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0
+ *
+ */
+
+#ifndef __SHORT_TERM_MEMORY_ITEM_HAND_H__
+#define __SHORT_TERM_MEMORY_ITEM_HAND_H__
+
+#include <yarp/os/LogStream.h>
+
+#include "MemoryItem.h"
+
+struct MemoryItemHand : public MemoryItem
+{
+    bool isFree;
+
+    // constructor
+    MemoryItemHand(const int _id, const string _name, const bool _isHand,
+                   bool _isFree)
+    : MemoryItem(_id,_name,_isHand),
+      isFree(_isFree)
+    {}
+
+    // copy constructor
+    MemoryItemHand(const MemoryItemHand& other)
+    : MemoryItem(other),
+      isFree(other.isFree)
+    {}
+
+    // copy assignment operator
+    MemoryItemHand& operator=(const MemoryItemHand& other)
+    {
+        // TODO: other fields
+        return *this;
+    }
+
+    // destructor
+    ~MemoryItemHand()
+    {}
+
+    virtual std::ostream& toString(std::ostream& o) const
+    {
+        // concatenate base class fields with derived fields
+        return MemoryItem::toString(o) << " "
+            << "isFree=" << (isFree?"true":"false");
+    }
+};
+
+#endif

--- a/src/worldStateManager/include/MemoryItemObj.h
+++ b/src/worldStateManager/include/MemoryItemObj.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright: (C) 2012-2015 POETICON++, European Commission FP7 project ICT-288382
+ * Copyright: (C) 2015 VisLab, Institute for Systems and Robotics,
+ *                Instituto Superior Técnico, Universidade de Lisboa, Lisbon, Portugal
+ * Author: Giovanni Saponaro <gsaponaro@isr.ist.utl.pt>
+ * CopyPolicy: Released under the terms of the GNU GPL v2.0
+ *
+ */
+
+#ifndef __SHORT_TERM_MEMORY_ITEM_OBJECT_H__
+#define __SHORT_TERM_MEMORY_ITEM_OBJECT_H__
+
+#include <yarp/os/Bottle.h>
+
+#include "MemoryItem.h"
+
+using namespace yarp::os;
+
+struct MemoryItemObj : public MemoryItem
+{
+    Bottle pos2d;
+    Bottle desc2d;
+    Bottle tooldesc2d;
+    string inHand;
+    Bottle onTopOf;
+    Bottle reachW;
+    Bottle pullW;
+
+    // constructors
+    MemoryItemObj(const int _id, const string _name, const bool _isHand)
+    : MemoryItem(_id,_name,_isHand)
+    {}
+
+    MemoryItemObj(const int _id, const string _name, const bool _isHand,
+                  Bottle _pos2d,
+                  Bottle _desc2d, Bottle _tooldesc2d,
+                  string _inHand,
+                  Bottle _onTopOf,
+                  Bottle _reachW, Bottle _pullW)
+    : MemoryItem(_id,_name,_isHand),
+      pos2d(_pos2d),
+      desc2d(_desc2d), tooldesc2d(_tooldesc2d),
+      inHand(_inHand),
+      onTopOf(_onTopOf),
+      reachW(_reachW), pullW(_pullW)
+    {}
+
+    // copy constructor
+    MemoryItemObj(const MemoryItemObj& other)
+    : MemoryItem(other),
+      pos2d(other.pos2d),
+      desc2d(other.desc2d),
+      tooldesc2d(other.tooldesc2d),
+      inHand(other.inHand),
+      onTopOf(other.onTopOf),
+      reachW(other.reachW),
+      pullW(other.pullW)
+    {}
+
+    // copy assignment operator
+    MemoryItemObj& operator=(const MemoryItemObj& other)
+    {
+        // TODO: other fields
+        return *this;
+    }
+
+    // destructor
+    ~MemoryItemObj()
+    {}
+
+    virtual std::ostream& toString(std::ostream& o) const
+    {
+        // concatenate base class fields with derived fields
+        return MemoryItem::toString(o) << " "
+            << "pos2d=" << pos2d.toString().c_str() << " "
+            << "desc2d=" << desc2d.toString().c_str() << " "
+            << "tooldesc2d=" << tooldesc2d.toString().c_str() << " "
+            << "in_hand=" << inHand << " "
+            << "on_top_of=" << onTopOf.toString().c_str() << " "
+            << "reachable_with=" << reachW.toString().c_str() << " "
+            << "pullable_with=" << pullW.toString().c_str();
+    }
+};
+
+#endif

--- a/src/worldStateManager/src/Helpers.cpp
+++ b/src/worldStateManager/src/Helpers.cpp
@@ -32,11 +32,3 @@ bool is_integer(const float k)
 {
     return std::floor(k)==k;
 }
-
-/**********************************************************/
-bool vectorsDiffer(const std::vector<int> &v1, const std::vector<int> &v2)
-{
-    return std::lexicographical_compare(v1.begin(),v1.end(),
-                                        v2.begin(),v2.end());
-}
-

--- a/src/worldStateManager/src/WorldStateMgrModule.cpp
+++ b/src/worldStateManager/src/WorldStateMgrModule.cpp
@@ -80,6 +80,7 @@ bool WorldStateMgrModule::close()
     yInfo("starting shutdown procedure");
     thread->interrupt();
     thread->close();
+    thread->stop();
     yInfo("deleting thread");
     if (thread) delete thread;
     yInfo("done deleting thread");
@@ -105,7 +106,7 @@ bool WorldStateMgrModule::attach(RpcServer &source)
 
 bool WorldStateMgrModule::dump()
 {
-    return thread->dumpWorldState();
+    return thread->printMemoryState();
 }
 
 bool WorldStateMgrModule::update()


### PR DESCRIPTION
Changes:
* more robust initialization: ensure that all object labels are different, otherwise repeat the process indefinitely (in the terminal, useful information about what is going on is printed);
* previously, restarting WSM required the user to restart ```activeParticleTrack``` and the WSOPC database as well. Now it is no longer the case (however, if the lighting conditions have changed a lot since APT was initialized, it is still a good idea to restart it. This is because the tracker could have "lost track" of one of the objects after some significant time/changes, and this situation would confuse WSM's initialization, cycling indefinitely - see previous point);
* now WSM has an internal short-term memory model (classes ```MemoryItemHand``` and ```MemoryItemObj```) that gets "copied" to the WSOPC database during an RPC ```update``` command;
* the new internal model data structures facilitate the job of higher-level reasoning on the data, such as temporal filtering and handling probabilities (still work in progress), and possible future reasoning like semantic checks between different objects/hands; the idea is that this internal model is refreshed frequently and autonomously (without user request); then, when a user requests an update via RPC, the latest consistent internal model data is "copied" onto the real WSOPC database;
* tested with real robot perception data, works fine so far;
* @AlexAntn, nothing changes for your perspective of using WSM via RPC: these modifications are internal to my module.

/cc @lorejam 