### PR TITLE
[planner] Debugging loadUsedObjs function, removed first subgoal on Goal Compiler

### DIFF
--- a/src/pradaPlanner-cpp/goalCompiler/src/goalCompilerModule.cpp
+++ b/src/pradaPlanner-cpp/goalCompiler/src/goalCompilerModule.cpp
@@ -88,11 +88,11 @@ bool goalCompiler::configure(ResourceFinder &rf)
                 cout << "failed to load instructions" << endl;
                 continue;
             }
-            if (!processFirstInst())
+/*            if (!processFirstInst())
             {
                 cout << "failed to process the first instruction" << endl;
                 continue;
-            }
+            }*/
             if (!compile())
             {
                 cout << "failed to compile goals" << endl;
@@ -316,7 +316,7 @@ bool goalCompiler::loadInstructions()
     return true;
 }
 
-bool goalCompiler::processFirstInst()
+/*bool goalCompiler::processFirstInst()
 {
     subgoals.clear();
 	action_sequence.clear();
@@ -478,7 +478,7 @@ bool goalCompiler::processFirstInst()
     }
     subgoals.push_back(aux_subgoal);
     return true;
-}
+}*/
 
 bool goalCompiler::compile()
 {
@@ -603,8 +603,12 @@ bool goalCompiler::compile()
                         }
                         new_temp_rule.erase(new_temp_rule.begin(),new_temp_rule.begin()+1);
                         aux_subgoal = new_temp_rule;
-                        vector<string> temp_subgoal = subgoals[subgoals.size()-1];
-                        for (int i = 0; i < aux_subgoal.size(); ++i){
+						vector<string> temp_subgoal;
+						if (subgoals.size() > 0)
+						{
+							temp_subgoal = subgoals[subgoals.size()-1];
+                        }
+						for (int i = 0; i < aux_subgoal.size(); ++i){
                             temp_subgoal.push_back(aux_subgoal[i]);
                         }
 						temp_action.clear();
@@ -647,8 +651,11 @@ bool goalCompiler::compile()
                         }
                         aux_subgoal = split(temp_str,' ');
                         aux_subgoal.erase(aux_subgoal.begin(),aux_subgoal.begin()+3);
-
-                        vector<string> temp_subgoal = subgoals[subgoals.size()-1];
+						vector<string> temp_subgoal;
+						if (subgoals.size() > 0)
+						{
+							temp_subgoal = subgoals[subgoals.size()-1];
+                        }
                         for (int i = 0; i < aux_subgoal.size(); ++i){
                             temp_subgoal.push_back(aux_subgoal[i]);
                         }

--- a/src/pradaPlanner-cpp/goalCompiler/src/goalCompilerModule.cpp
+++ b/src/pradaPlanner-cpp/goalCompiler/src/goalCompilerModule.cpp
@@ -603,12 +603,12 @@ bool goalCompiler::compile()
                         }
                         new_temp_rule.erase(new_temp_rule.begin(),new_temp_rule.begin()+1);
                         aux_subgoal = new_temp_rule;
-						vector<string> temp_subgoal;
+                        vector<string> temp_subgoal;
 						if (subgoals.size() > 0)
-						{
-							temp_subgoal = subgoals[subgoals.size()-1];
+                        {
+                            temp_subgoal = subgoals[subgoals.size()-1];
                         }
-						for (int i = 0; i < aux_subgoal.size(); ++i){
+                        for (int i = 0; i < aux_subgoal.size(); ++i){
                             temp_subgoal.push_back(aux_subgoal[i]);
                         }
 						temp_action.clear();
@@ -651,10 +651,10 @@ bool goalCompiler::compile()
                         }
                         aux_subgoal = split(temp_str,' ');
                         aux_subgoal.erase(aux_subgoal.begin(),aux_subgoal.begin()+3);
-						vector<string> temp_subgoal;
-						if (subgoals.size() > 0)
-						{
-							temp_subgoal = subgoals[subgoals.size()-1];
+                        vector<string> temp_subgoal;
+                        if (subgoals.size() > 0)
+                        {
+                            temp_subgoal = subgoals[subgoals.size()-1];
                         }
                         for (int i = 0; i < aux_subgoal.size(); ++i){
                             temp_subgoal.push_back(aux_subgoal[i]);

--- a/src/pradaPlanner-cpp/planningCycle/src/PlannerThread.cpp
+++ b/src/pradaPlanner-cpp/planningCycle/src/PlannerThread.cpp
@@ -999,18 +999,18 @@ bool PlannerThread::loadUsedObjs()
             aux_used.push_back(object_IDs[y][0]);
         }
     }
-	yDebug("Objects used in last action:");
+    yDebug("Objects used in last action:");
     for (int u = 0; u < aux_used.size(); ++u){
-		yDebug("%s", aux_used[u].c_str());
+        yDebug("%s", aux_used[u].c_str());
         if (find_element(toolhandle,aux_used[u]) == 0 && find_element(objects_used, aux_used[u]) == 0){
             objects_used.push_back(aux_used[u]);
         }
     }
-	yDebug("Objects used until now:");
-	for (int u = 0; u < objects_used.size(); ++u)
-	{
-		yDebug("%s", objects_used[u].c_str());
-	}
+    yDebug("Objects used until now:");
+    for (int u = 0; u < objects_used.size(); ++u)
+    {
+        yDebug("%s", objects_used[u].c_str());
+    }
     return true;
 }
 

--- a/src/pradaPlanner-cpp/planningCycle/src/PlannerThread.cpp
+++ b/src/pradaPlanner-cpp/planningCycle/src/PlannerThread.cpp
@@ -999,11 +999,18 @@ bool PlannerThread::loadUsedObjs()
             aux_used.push_back(object_IDs[y][0]);
         }
     }
+	yDebug("Objects used in last action:");
     for (int u = 0; u < aux_used.size(); ++u){
+		yDebug("%s", aux_used[u].c_str());
         if (find_element(toolhandle,aux_used[u]) == 0 && find_element(objects_used, aux_used[u]) == 0){
             objects_used.push_back(aux_used[u]);
         }
     }
+	yDebug("Objects used until now:");
+	for (int u = 0; u < objects_used.size(); ++u)
+	{
+		yDebug("%s", objects_used[u].c_str());
+	}
     return true;
 }
 


### PR DESCRIPTION
Inserted some debugging prints on the loadUsedObjs function. See #166

Removed the "process first instruction" function from the Goal Compiler, that created a subgoal from the context of the first instruction. It sometimes conflicts with the adaptability heuristic.