### PR TITLE
planner: add requisite to putting action, nothing over obj

### DIFF
--- a/app/conf/pre_rules.dat
+++ b/app/conf/pre_rules.dat
@@ -43,7 +43,7 @@ OUTCOMES:
 ACTION:
   put__tool_on__obj_with__hand()
 CONTEXT:
-  -_tool_ishand() _obj_isreachable_with__hand() -_obj_ishand() _tool_inhand__hand()
+  -_tool_ishand() _obj_isreachable_with__hand() -_obj_ishand() _tool_inhand__hand() -_ALL_on__obj()
 OUTCOMES:
   0.7 _tool_on__obj() -_tool_inhand__hand() _hand_clearhand()
   0.15 -_tool_inhand__hand() _hand_clearhand()

--- a/app/conf/pre_rules_deterministic.dat
+++ b/app/conf/pre_rules_deterministic.dat
@@ -43,7 +43,7 @@ OUTCOMES:
 ACTION:
   put__tool_on__obj_with__hand()
 CONTEXT:
-  -_tool_ishand() _obj_isreachable_with__hand() -_obj_ishand() _tool_inhand__hand()
+  -_tool_ishand() _obj_isreachable_with__hand() -_obj_ishand() _tool_inhand__hand() -_ALL_on__obj()
 OUTCOMES:
   0.85 _tool_on__obj() -_tool_inhand__hand() _hand_clearhand()
   #0.15 -_tool_inhand__hand() _hand_clearhand()


### PR DESCRIPTION
This change restricts the action "put obj1 on obj2" so that obj2 must have nothing over it as a pre-requisite.

Because the goal is defined as a stack (e.g., 2 on 1, 3 on 2, etc.), this change does not affect the goal itself. However, this change affects the Goal Compiler, which will now represent the new pre-requisites in the sub-goals explicitly.

See also https://github.com/robotology/poeticon/pull/201/commits/642bac6ec9a9170adf2ffb9d2de9fe3d8f0774ec

Thanks @AlexAntn